### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ if(WIN32)
 
   if(MSVC)
 
-    set(MSVC_CXX_FLAGS "-std=gnu++11")
+    set(MSVC_CXX_FLAGS "/std:c++14 /O2")
 
     if(BUILD_DEBUG)
         set(CMAKE_BUILD_TYPE Debug)
@@ -135,7 +135,7 @@ if(WIN32)
 
   if(MINGW)
 
-    set(MSVC_CXX_FLAGS "-std=gnu++11")
+    set(MSVC_CXX_FLAGS "/std:c++14 /O2")
 
     if(BUILD_DEBUG)
         set(CMAKE_BUILD_TYPE Debug)


### PR DESCRIPTION
MSVC doesn't use GNU style flags.

Optimization flags:
https://docs.microsoft.com/en-us/cpp/build/reference/o-options-optimize-code?view=vs-2017

MSVC does not have c++11 flags, the oldest is c++14
https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=vs-2017